### PR TITLE
Fix log rotation by reopening log

### DIFF
--- a/commands/logger.go
+++ b/commands/logger.go
@@ -1,0 +1,36 @@
+package commands
+
+import (
+	"log"
+	"os"
+
+	"margem/robo/helpers"
+)
+
+var (
+	logFile     *os.File
+	logFilePath string
+)
+
+// SetLogFile sets the current log file handle and path used by commands.
+func SetLogFile(f *os.File, path string) {
+	logFile = f
+	logFilePath = path
+}
+
+// reopenLogFile closes the current log file, rotates if needed, and reopens it.
+func reopenLogFile() error {
+	if logFile != nil {
+		logFile.Close()
+	}
+	if err := helpers.RotateLogIfNeeded(logFilePath); err != nil {
+		return err
+	}
+	f, err := os.OpenFile(logFilePath, os.O_APPEND|os.O_CREATE|os.O_WRONLY, 0666)
+	if err != nil {
+		return err
+	}
+	logFile = f
+	log.SetOutput(logFile)
+	return nil
+}

--- a/commands/run.go
+++ b/commands/run.go
@@ -3,10 +3,10 @@ package commands
 import (
 	"database/sql"
 	"log"
-	"margem/robo/helpers"
+	"time"
+
 	"margem/robo/models/config"
 	"margem/robo/repository"
-	"time"
 )
 
 // -----------------------------------------------------------------------------
@@ -25,7 +25,6 @@ func Run(
 	cfg config.Config,
 	modoLog string,
 ) {
-	logFilePath := "./config/log.txt" // Caminho para o arquivo de log
 	log.Printf("🚀 Run iniciado | ciclo normal: %d min | extra: %02d:%02d",
 		interval, extraHour, extraMin)
 
@@ -45,7 +44,7 @@ func Run(
 		// Verifica e rotaciona o log a cada 10 ciclos
 		cycleCount++
 		if cycleCount >= 10 {
-			checkAndRotateLog(logFilePath)
+			checkAndRotateLog()
 			cycleCount = 0
 		}
 
@@ -61,7 +60,6 @@ func scheduleExtra(
 	cfg config.Config,
 	modoLog string,
 ) {
-	logFilePath := "./config/log.txt"
 	for {
 		now := time.Now()
 		next := time.Date(now.Year(), now.Month(), now.Day(),
@@ -81,7 +79,7 @@ func scheduleExtra(
 		syncPreviousThreeDays(reportRepos, dbMap, cfg, modoLog, time.Now())
 
 		// Verifica e rotaciona o log após o processamento extra
-		checkAndRotateLog(logFilePath)
+		checkAndRotateLog()
 	}
 }
 
@@ -103,8 +101,8 @@ func syncPreviousThreeDays(
 }
 
 // checkAndRotateLog verifica e rotaciona o log se necessário
-func checkAndRotateLog(logFilePath string) {
-	if err := helpers.RotateLogIfNeeded(logFilePath); err != nil {
+func checkAndRotateLog() {
+	if err := reopenLogFile(); err != nil {
 		log.Printf("⚠️ [Run] Erro ao rotacionar log: %v", err)
 	}
 }

--- a/main.go
+++ b/main.go
@@ -108,6 +108,7 @@ func main() {
 	}
 	defer logFile.Close()
 	log.SetOutput(logFile)
+	commands.SetLogFile(logFile, logFilePath)
 
 	// Exibe o guia de uso somente se solicitado
 	if len(os.Args) < 2 || containsHelp(os.Args[1:]) {


### PR DESCRIPTION
## Summary
- add a logger helper in commands package to manage log file
- reopen the log file whenever rotation is requested
- register log file from main

## Testing
- `go build ./...` *(fails: proxyconnect tcp: dial tcp 172.27.0.3:8080: connect: no route to host)*