### PR TITLE
Fix log file helpers

### DIFF
--- a/commands/logger.go
+++ b/commands/logger.go
@@ -18,8 +18,8 @@ func SetLogFile(f *os.File, path string) {
 	logFilePath = path
 }
 
-// reopenLogFile closes the current log file, rotates if needed, and reopens it.
-func reopenLogFile() error {
+// ReopenLogFile closes the current log file, rotates if needed, and reopens it.
+func ReopenLogFile() error {
 	if logFile != nil {
 		logFile.Close()
 	}

--- a/commands/run.go
+++ b/commands/run.go
@@ -102,7 +102,7 @@ func syncPreviousThreeDays(
 
 // checkAndRotateLog verifica e rotaciona o log se necessário
 func checkAndRotateLog() {
-	if err := reopenLogFile(); err != nil {
+	if err := ReopenLogFile(); err != nil {
 		log.Printf("⚠️ [Run] Erro ao rotacionar log: %v", err)
 	}
 }


### PR DESCRIPTION
## Summary
- export log rotation helper
- rename reference in run loop

## Testing
- `go vet ./...` *(fails: proxyconnect tcp: connect: no route to host)*