### PR TITLE
Ensure log file permissions

### DIFF
--- a/helpers/file_permissions.go
+++ b/helpers/file_permissions.go
@@ -1,0 +1,21 @@
+package helpers
+
+import (
+	"os"
+	"path/filepath"
+)
+
+// EnsureLogFile creates the log file and its parent directory if needed
+// and sets its permissions to allow read/write for all users.
+func EnsureLogFile(logPath string) error {
+	dir := filepath.Dir(logPath)
+	if err := os.MkdirAll(dir, 0777); err != nil {
+		return err
+	}
+	f, err := os.OpenFile(logPath, os.O_CREATE, 0666)
+	if err != nil {
+		return err
+	}
+	f.Close()
+	return os.Chmod(logPath, 0666)
+}

--- a/main.go
+++ b/main.go
@@ -90,6 +90,11 @@ func main() {
 	fmt.Println("⚙️ Configurando arquivo de Log em ./config/log.txt")
 	logFilePath := "./config/log.txt"
 
+	// Garante a existência do arquivo e as permissões corretas
+	if err := helpers.EnsureLogFile(logFilePath); err != nil {
+		log.Fatalf("Erro ao garantir arquivo de log: %v", err)
+	}
+
 	// Verifica o tamanho atual do log antes da rotação
 	currentSize, err := helpers.CheckLogSize(logFilePath)
 	if err == nil && currentSize > 0 {


### PR DESCRIPTION
## Summary
- add helper to create log file with 0666 permissions
- ensure the log file exists and has proper permissions before logging starts

## Testing
- `go build ./...` *(fails: no route to host)*